### PR TITLE
Correcting "weight_pounds" function

### DIFF
--- a/NHANES.ipynb
+++ b/NHANES.ipynb
@@ -2425,7 +2425,7 @@
    "source": [
     "#define function weight_pounds to calculate weight in pounds\n",
     "def weight_pounds(x):\n",
-    "    print(x*2.205)"
+    "    return(x*2.205)"
    ]
   },
   {


### PR DESCRIPTION
`weight_pounds` prints its output which is why the notebook cell produces over 4 thousand lines of output after you run it. What you really want is for the function to `return` a value. With this change the "WeightPounds" will contain the correct values as you intended.